### PR TITLE
Modify playbook compiler to flush handlers after each role.

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -227,6 +227,16 @@ class Play(Base, Taggable, Become, CollectionSearch):
 
         block_list = []
 
+        # create a block containing a single flush handlers meta
+        # task, so we can be sure to run handlers at certain points
+        # of the playbook execution
+        flush_block = Block.load(
+            data={'meta': 'flush_handlers'},
+            play=self,
+            variable_manager=self._variable_manager,
+            loader=self._loader
+        )
+
         if len(self.roles) > 0:
             for r in self.roles:
                 # Don't insert tasks from ``import/include_role``, preventing
@@ -234,6 +244,7 @@ class Play(Base, Taggable, Become, CollectionSearch):
                 if r.from_include:
                     continue
                 block_list.extend(r.compile(play=self))
+                block_list.append(flush_block)
 
         return block_list
 


### PR DESCRIPTION
##### SUMMARY

A small change that I think will go completely unnoticed by people who don't care but make a big difference by people that do (i.e me).

The problem I run into is having to put awkward logic into roles that are used as dependencies because handlers are run too late.

```
# In dependent role.
install a new profile into /etc/supervisor.d
register a handler for supervisor to reload its config

# In main role.
start and enable the newly installed profile // error no such process
```

Yes it's a small annoyance but dammit this is how it should have worked from the beginning. There's a precedent for it too since handlers registered in `pre_tasks` are called before roles.

##### ISSUE TYPE

- Feature Pull Request