### PR TITLE
Add an option to ignore role dependencies

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1456,6 +1456,14 @@ INTERPRETER_PYTHON:
     value of ``auto_legacy`` provides all the same behavior, but for backwards-compatibility with older Ansible releases
     that always defaulted to ``/usr/bin/python``, will use that interpreter if present (and issue a warning that the
     default behavior will change to that of ``auto`` in a future Ansible release.
+IGNORE_ROLE_DEPENDENCIES:
+  name: Ignore role dependencies
+  default: False
+  description:
+    - Skip dependencies for roles.
+  env: [{name: ANSIBLE_IGNORE_ROLE_DEPENDENCIES}]
+  ini: [{key: ignore_role_dependencies, section: defaults}]
+  type: boolean
 INTERPRETER_PYTHON_DISTRO_MAP:
   name: Mapping of known included platform pythons for various Linux distros
   default:

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -21,6 +21,7 @@ __metaclass__ = type
 
 import os
 
+from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleParserError, AnsibleAssertionError
 from ansible.module_utils.six import iteritems, binary_type, text_type
 from ansible.module_utils.common._collections_compat import Container, Mapping, Set, Sequence
@@ -294,7 +295,7 @@ class Role(Base, Become, Conditional, Taggable, CollectionSearch):
         '''
 
         deps = []
-        if self._metadata:
+        if self._metadata and not C.IGNORE_ROLE_DEPENDENCIES:
             for role_include in self._metadata.dependencies:
                 r = Role.load(role_include, play=self._play, parent_role=self)
                 deps.append(r)


### PR DESCRIPTION
Super simple change to allow running roles while skipping their dependencies.

```
ANSIBLE_IGNORE_ROLE_DEPENDENCIES=true ansible-playbook roles/debian/check_mk_agent/plays/apply.yml
```