### PR TITLE
Add option to ignore SELinux binding check

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1464,6 +1464,18 @@ IGNORE_ROLE_DEPENDENCIES:
   env: [{name: ANSIBLE_IGNORE_ROLE_DEPENDENCIES}]
   ini: [{key: ignore_role_dependencies, section: defaults}]
   type: boolean
+IGNORE_MISSING_SELINUX_BINDINGS:
+  name: Ignore missing SELinux bindings when performing file operations.
+  default: False
+  description:
+    - Allows modules that perform file operations to be run on a system where the SELinux python bindings are missing
+      or not yet present.
+  env: [{name: ANSIBLE_IGNORE_MISSING_SELINUX_BINDINGS}]
+  ini:
+    - {key: ignore_missing_selinux_bindings, section: defaults}
+  vars:
+    - {name: ansible_ignore_missing_selinux_bindings}
+  version_added: "2.9"
 INTERPRETER_PYTHON_DISTRO_MAP:
   name: Mapping of known included platform pythons for various Linux distros
   default:

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -824,7 +824,7 @@ class AnsibleModule(object):
             seenabled = self.get_bin_path('selinuxenabled')
             if seenabled is not None:
                 (rc, out, err) = self.run_command(seenabled)
-                if rc == 0:
+                if rc == 0 and not self.ignore_missing_selinux_bindings:
                     self.fail_json(msg="Aborting, target uses selinux but python bindings (libselinux-python) aren't installed!")
             return False
         if selinux.is_selinux_enabled() == 1:

--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -36,9 +36,10 @@ PASS_VARS = {
     'tmpdir': ('_tmpdir', None),
     'verbosity': ('_verbosity', 0),
     'version': ('ansible_version', '0.0'),
+    'ignore_missing_selinux_bindings': ('ignore_missing_selinux_bindings', False)
 }
 
-PASS_BOOLS = ('check_mode', 'debug', 'diff', 'keep_remote_files', 'no_log')
+PASS_BOOLS = ('check_mode', 'debug', 'diff', 'keep_remote_files', 'no_log', 'ignore_missing_selinux_bindings')
 
 
 def _return_datastructure_name(obj):

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -738,6 +738,9 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         # make sure modules are aware if they need to keep the remote files
         module_args['_ansible_keep_remote_files'] = C.DEFAULT_KEEP_REMOTE_FILES
 
+        # let module know if they should ignore SELinux bindings
+        module_args['_ansible_ignore_missing_selinux_bindings'] = C.IGNORE_MISSING_SELINUX_BINDINGS
+
         # make sure all commands use the designated temporary directory if created
         if self._is_become_unprivileged():  # force fallback on remote_tmp as user cannot normally write to dir
             module_args['_ansible_tmpdir'] = None


### PR DESCRIPTION
Patch which adds a new config option `ignore_missing_selinux_bindings` and `ANSIBLE_IGNORE_MISSING_SELINUX_BINDINGS`.

Ansible does a bad when it comes to SELinux bindings. Modules that use any of the file operation methods that come with `module_utils` have a hard dependency on the `selinux` python module when SELinux is enabled on the host. This presents a problem when bootstrapping the system because `yum/dnf/package/redhat_subscription` use these methods which means you have to drop to a `raw` invocation to get them installed.

It's also annoying when you run Ansible in a virtualenv on hosts with SELinux. The `selinux` python module only ships as a system package so you can't install it in your virtualenv without using `--site-packages` which has it's own issues. So if you run Ansible against your own host it breaks which might be fine except it also affects `delegate_to: localhost`.