### PR TITLE
Change the default params to `to_nice_yaml`.

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -66,9 +66,9 @@ def to_yaml(a, *args, **kw):
     return to_text(transformed)
 
 
-def to_nice_yaml(a, indent=4, *args, **kw):
+def to_nice_yaml(a, indent=2, sort_keys=False, *args, **kw):
     '''Make verbose, human readable yaml'''
-    transformed = yaml.dump(a, Dumper=AnsibleDumper, indent=indent, allow_unicode=True, default_flow_style=False, **kw)
+    transformed = yaml.dump(a, Dumper=AnsibleDumper, indent=indent, allow_unicode=True, default_flow_style=False, sort_keys=sort_keys, **kw)
     return to_text(transformed)
 
 


### PR DESCRIPTION
In reference to https://github.com/ansible/ansible/issues/16707

As of Python 3.7 order is guaranteed and we should take advantage of it because the default behavior of sorting keys is silly. You end up doing more work for worse output. Now when you do something like the following 

```
- name: Example Task
  copy:
    dest: /etc/example/10-config.yml
    content: |
      {{ example_var | to_nice_yaml }}
  vars:
    example_var:
      hello: world
      foo: [bar, baz]
```

the file on disk matches what's in the playbook, indentation and all.

I can't for the life of me find where this option is documented but it's [here](https://github.com/yaml/pyyaml/blob/ee37f4653c08fc07aecff69cfd92848e6b1a540e/lib3/yaml/dumper.py#L16).