### PR TITLE
Show correct changed output in check mode

### DIFF
--- a/lib/ansible/modules/commands/command.py
+++ b/lib/ansible/modules/commands/command.py
@@ -293,11 +293,9 @@ def main():
 
     if not module.check_mode:
         rc, out, err = module.run_command(args, executable=executable, use_unsafe_shell=shell, encoding=None, data=stdin, binary_data=(not stdin_add_newline))
-    elif creates or removes:
+    else:
         rc = 0
         out = err = b'Command would have run if not in check mode'
-    else:
-        module.exit_json(msg="skipped, running in check mode", skipped=True)
 
     endd = datetime.datetime.now()
     delta = endd - startd

--- a/lib/ansible/modules/commands/command.py
+++ b/lib/ansible/modules/commands/command.py
@@ -79,6 +79,12 @@ options:
     version_added: "2.8"
     type: bool
     default: yes
+  mock:
+    description:
+      - Mock the result code and output when running in check mode.
+      - The C(rc), C(stdout), and C(stderr) keys can be provided.
+    version_added: "2.8"
+    type: dict
 notes:
     -  If you want to run a command through the shell (say you are using C(<), C(>), C(|), etc), you actually want the M(shell) module instead.
        Parsing shell metacharacters can lead to unexpected commands being executed if quoting is not done correctly so it is more secure to
@@ -224,6 +230,7 @@ def main():
             stdin=dict(required=False),
             stdin_add_newline=dict(type='bool', default=True),
             strip_empty_ends=dict(type='bool', default=True),
+            mock=dict(type='dict')
         ),
         supports_check_mode=True,
     )
@@ -238,6 +245,7 @@ def main():
     stdin = module.params['stdin']
     stdin_add_newline = module.params['stdin_add_newline']
     strip = module.params['strip_empty_ends']
+    mock = module.params['mock']
 
     if not shell and executable:
         module.warn("As of Ansible 2.4, the parameter 'executable' is no longer supported with the 'command' module. Not using '%s'." % executable)
@@ -294,8 +302,13 @@ def main():
     if not module.check_mode:
         rc, out, err = module.run_command(args, executable=executable, use_unsafe_shell=shell, encoding=None, data=stdin, binary_data=(not stdin_add_newline))
     else:
-        rc = 0
-        out = err = b'Command would have run if not in check mode'
+        if mock:
+            rc = mock.get('rc', 0)
+            out = mock.get('stdout', '')
+            err = mock.get('stderr', '')
+        else:
+            rc = 0
+            out = err = b'Command would have run if not in check mode'
 
     endd = datetime.datetime.now()
     delta = endd - startd


### PR DESCRIPTION
 Show correct changed output in check mode

Right now the command module has silly behavior in check mode. If the command is skipped because of a when block or something it shows as skipped. But if the command would actually run it ALSO shows as skipped despite the fact that the module knows that the command would run.

I'm not the only one annoyed by this either. This fixes:

* ansible#14075
* ansible#9508

Don't tell me that command doesn't support check mode when `supports_check_mode=True`.

In addition there is another feature added that I simplifies annoying logic when trying to use check mode to run binaries that are created by the playbook itself -- mocks!

```yaml
- apt:
    name: awscli

- name: Install credentials
  template:
    src: ...
    dest: ...

- name: Run some command
  command: aws ec2 create-vpc ...
  register: aws_vpc

- name: Do something with the result
  lineinfile:
    dest: /etc/app/app.conf
    line: "vpc={{ (aws_vpc.stdout | to_json).Vpc.VpcId }}"
```

If you run this in check mode it will fail because `Run some command` is skipped and so the variable will never be defined. And if you add `check_mode: false` to that task to fix it it will also fail because the `aws` command isn't found. So you actually need to have a separate task to check if the `aws` command exists and use that to skip both tasks but then you lose the information that in reality both of these tasks would be changed which defeats the entire point of check mode.

With these patches we can do

```yaml
- name: Run some command
  command: aws ec2 create-vpc ...
  args:
    mock:
      stdout: |
        {
          "Vpc": {
            ...
          }
        }
  register: aws_alias
```

And everything will "just work." In the case of an information gathering command you can do one better but it requires that you check for the command existence.

```yaml
- name: Check if the aws command exists
  stat:
    path: /bin/aws
  register: aws_cmd

- name: Run some command
  command: aws sts get-caller-name
  args:
    mock:
      stdout: |
        {
         "UserId": "AIDASAMPLEUSERID",
         "Account": "123456789012",
         "Arn": "arn:aws:iam::123456789012:user/DevAdmin"
        }
  register: aws_alias
  check_mode: "{{ not aws_cmd.stat.exists }}"
  changed_when: false
```

Which will use the mock if the `aws` command doesn't exist but actually run it if it does.